### PR TITLE
Update Typst GitHub Action to ^0.15.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: typst-community/setup-typst@v4
         with:
-          typst-version: ^0.14.0
+          typst-version: ^0.15.0
       - uses: actions/configure-pages@v5
       - run: typst compile resume.typ resume.pdf
       - uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
### Motivation
- Use the newer Typst release in CI by switching the action to `^0.15.0` to pick up recent fixes and improvements.

### Description
- Bump `typst-version` in `.github/workflows/main.yml` from `^0.14.0` to `^0.15.0` in the `typst-community/setup-typst@v4` step.

### Testing
- No automated tests were executed as part of this PR; the workflow is configured to run on push and will invoke `typst compile resume.typ resume.pdf` when triggered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a679d1129f88326a59204c7b1632fa0)